### PR TITLE
Ajout de .DS_Store dans le gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ dkms.conf
 *.swp
 .~
 thumbs.db
+.DS_Store # This is for the mac tempory files


### PR DESCRIPTION
Il n'a pas a y avoir de .DS_Store dans un git sachant que c'est un fichier d'info mac !
